### PR TITLE
Add clarification to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ python3 -V
 Python 3.6.3
 
 python2 -V
-2.7.13
+Python 2.7.13
 ```
 
 In some cases, you might want python2 and python3 to co-exist, but python needs to point at a specific python version. The order of python versions is what controls this.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,20 @@ This can be achieved by setting multiple versions of Python, for example with
 asdf global python 3.6.2 2.7.13
 ```
 
-This feature is experimental but should be working well enough for most use cases.
+This feature is experimental but should be working well enough for most use cases. Incidentally, the first python version you install will claim `python`. With the above example:
+
+```
+python -V
+Python 3.6.3
+
+python3 -V
+Python 3.6.3
+
+python2 -V
+2.7.13
+```
+
+In some cases, you might want python2 and python3 to co-exist, but python needs to point at a specific python version. The order of python versions is what controls this.
 
 ## Pip installed modules and binaries
 


### PR DESCRIPTION
I recently ran into a problem where I was running python2 and python3 side by side, but some scripts have a shebang specifying `#!/usr/bin/env python`

It appears that the order of versions in `asdf global 3.7.3 2.7.15` matters. The first version you set will claim the `python` binary. `python2` and `python3` act as expected.

I added some clarification to the documentation to explain this, just in case it isn't obvious. It wasn't to me, but maybe in retrospect it should have been.

I think it worth documenting, but I am not attached to any of the verbiage in my documentation, so if you need to edit it, it is totally fine with me.

Thanks! 