### PR TITLE
Remove repo URL from installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Python plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 ## Install
 
 ```
-asdf plugin-add python https://github.com/danhper/asdf-python.git
+asdf plugin-add python
 ```
 
 ## Use


### PR DESCRIPTION
Thus `asdf-python` is a known `asdf` plugin, repo URL is excess.