### PR TITLE
Fix default packages support and document the feature in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,12 @@ Python 2.7.13
 ## Pip installed modules and binaries
 
 If you use pip to install a module like ipython that has a binaries. You will need to run `asdf reshim python` for the binary to be in your path.
+
+## Default Python packages
+
+asdf-python can automatically install a default set of Python packages with pip right after installing a Python version. To enable this feature, provide a `$HOME/.default-python-packages` file that lists one package per line, for example:
+
+```
+ansible
+pipenv
+```

--- a/bin/install
+++ b/bin/install
@@ -22,13 +22,16 @@ install_python() {
 
 install_default_python_packages() {
   local default_python_packages="${HOME}/.default-python-packages"
-   if [ ! -f $default_python_packages ]; then return; fi
-   for name in $(cat $default_python_packages); do
-    echo -ne "\nInstalling \e[33m${name}\e[39m python package ... "
-     if pip install $name > /dev/null 2>&1; then
-      echo -e "\e[32mSUCCESS\e[39m"
+
+  if [ ! -f $default_python_packages ]; then return; fi
+
+  cat "$default_python_packages" | while read -r name; do
+    echo -ne "\nInstalling \033[33m${name}\033[39m python package... "
+    PATH="$ASDF_INSTALL_PATH/bin:$PATH" pip install "$name" > /dev/null 2>&1 && rc=$? || rc=$?
+    if [[ $rc -eq 0 ]]; then
+      echo -e "\033[32mSUCCESS\033[39m"
     else
-      echo -e "\e[31mFAIL\e[39m"
+      echo -e "\033[31mFAIL\033[39m"
     fi
   done
 }


### PR DESCRIPTION
This PR fixes default package support which currently does not seem to work. I used asdf-nodejs as a guide for how to get this to work correctly (https://github.com/asdf-vm/asdf-nodejs/blob/8bbe1ed8554a54a73b2d7f3663843a3f6bdb47fb/bin/install#L260).

The feature is also now documented in the README.