### PR TITLE
Support $ASDF_PYTHON_DEFAULT_PACKAGES_FILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,5 @@ asdf-python can automatically install a default set of Python packages with pip 
 ansible
 pipenv
 ```
+
+You can specify a non-default location of this file by setting a `ASDF_PYTHON_DEFAULT_PACKAGES_FILE` variable.

--- a/bin/install
+++ b/bin/install
@@ -21,11 +21,11 @@ install_python() {
 }
 
 install_default_python_packages() {
-  local default_python_packages="${HOME}/.default-python-packages"
+  local packages_file="${ASDF_PYTHON_DEFAULT_PACKAGES_FILE:-$HOME/.default-python-packages}"
 
-  if [ ! -f $default_python_packages ]; then return; fi
+  if [ ! -f "$packages_file" ]; then return; fi
 
-  cat "$default_python_packages" | while read -r name; do
+  while read -r name; do
     echo -ne "\nInstalling \033[33m${name}\033[39m python package... "
     PATH="$ASDF_INSTALL_PATH/bin:$PATH" pip install "$name" > /dev/null 2>&1 && rc=$? || rc=$?
     if [[ $rc -eq 0 ]]; then
@@ -33,7 +33,7 @@ install_default_python_packages() {
     else
       echo -e "\033[31mFAIL\033[39m"
     fi
-  done
+  done < "$packages_file"
 }
 
 ensure_python_build_installed


### PR DESCRIPTION
For those who, like me, despise having random config files all over $HOME, here's an option for keeping `.default-python-packages` somewhere else - e.g. in my case it's `~/.config/asdf/python-default-packages`.