### PR TITLE
Added help scripts

### DIFF
--- a/bin/help.config
+++ b/bin/help.config
@@ -1,0 +1,9 @@
+# Output should be freeform text. asdf decides how to reformat it.
+
+echo 'asdf-python can automatically install a default set of Python packages with pip right after installing a Python version. To enable this feature, provide a $HOME/.default-python-packages file that lists one package per line, for example:
+
+  ansible
+  pipenv
+
+You can specify a non-default location of this file by setting a ASDF_PYTHON_DEFAULT_PACKAGES_FILE variable.
+'

--- a/bin/help.links
+++ b/bin/help.links
@@ -1,0 +1,6 @@
+# Output should be <title>: <link>
+
+echo 'home-page: https://github.com/danhper/asdf-python
+dependencies: https://github.com/pyenv/pyenv/wiki#suggested-build-environment
+troubleshooting: https://github.com/pyenv/pyenv/wiki/Common-build-problems
+'

--- a/bin/help.overview
+++ b/bin/help.overview
@@ -1,0 +1,15 @@
+# Output should be freeform text. asdf decides how to reformat it.
+
+echo 'Basic usage:
+
+  asdf install python 3.6.12
+  asdf global python 3.6.12
+  python -V
+  Python 3.6.12
+
+Check the asdf documentation for more instructions on how to install & manage versions of Python. Please make sure you have the required system dependencies installed before trying to install Python.
+
+If you use pip to install a module like `ipython` that has binaries, you will need to run `asdf reshim python` for the binary to be in your path.
+
+Under the hood, asdf-python uses python-build (the same backend of pyenv) to build and install Python. Check its readme for more information about build options and the common build problems wiki page for any issues encountered during installation of python versions.
+'


### PR DESCRIPTION
asdf 0.8 added support for plugins to provide custom documentation scripts asdf-vm/asdf#757.

I mostly copied the readme to provide this documentation, so this can definitely be improved in the future. I chose to omit `help.deps` since it seems there is a lot of specific information for each OS to get `python-build` to work. The [link](https://github.com/pyenv/pyenv/wiki#suggested-build-environment) is provided in `help.links` though.