### PR TITLE
feat: support patching during install

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -16,8 +16,14 @@ install_python() {
   fi
   install_or_update_python_build
 
-  echo "python-build $version $install_path"
-  $(python_build_path) "$version" "$install_path"
+  local patch_file=${ASDF_PYTHON_PATCHES_DIRECTORY}/${version}.patch
+  if [ -f "$patch_file" ]; then
+    echo "python-build $version $install_path -p < $patch_file"
+    $(python_build_path) "$version" "$install_path" -p < $patch_file
+  else
+    echo "python-build $version $install_path"
+    $(python_build_path) "$version" "$install_path"
+  fi
 }
 
 install_default_python_packages() {


### PR DESCRIPTION
`python-build` supports a `-p` option to patch Python before installing. In
particular, I use this to apply a patch for OS X Big Sur before installing
older versions of Python.

I'm not super-wedded to this particular implementation: opening this PR for
more discussion.