### PR TITLE
Support upgrades and requirements.txt syntax for default packages

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -33,17 +33,10 @@ install_python() {
 install_default_python_packages() {
   local packages_file="${ASDF_PYTHON_DEFAULT_PACKAGES_FILE:-$HOME/.default-python-packages}"
 
-  if [ ! -f "$packages_file" ]; then return; fi
-
-  while read -r name; do
-    echo -ne "\nInstalling \033[33m${name}\033[39m python package... "
-    PATH="$ASDF_INSTALL_PATH/bin:$PATH" pip install "$name" > /dev/null 2>&1 && rc=$? || rc=$?
-    if [[ $rc -eq 0 ]]; then
-      echo -e "\033[32mSUCCESS\033[39m"
-    else
-      echo -e "\033[31mFAIL\033[39m"
-    fi
-  done < "$packages_file"
+  if [ -f "$packages_file" ]; then
+    echo -ne "\nInstalling default python packages..."
+    PATH="$ASDF_INSTALL_PATH/bin:$PATH" pip install -U -r "$packages_file"
+  fi
 }
 
 ensure_python_build_installed


### PR DESCRIPTION
I'd argue that the current solution is too custom for no real benefit. Python/pip already has a standard way to specify package names line-by-line in a file, which is requirements.txt syntax, so let's just use that!
We get version pinning, version conflict resolution for multiple packages and comments for free.

Also add `-U` to be able to update vendored packages like pip.

Resolves #105, obsoletes #126 and #92 if you don't mind :)