### PR TITLE
added major/minor shorthands

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -6,8 +6,12 @@ source "$(dirname "$0")/utils.sh"
 
 install_python() {
   local install_type=$1
-  local version=$2
-  local install_path=$3
+  local version
+  local symlink_path=$3
+  local install_path
+
+  version="$(resolve_partial_version "$2")"
+  install_path="$(dirname "$symlink_path")/$version"
 
   if [ "$install_type" != "version" ]; then
     echoerr "Cannot install specific ref from source, sorry."
@@ -28,6 +32,13 @@ install_python() {
     echo "python-build $version $install_path"
     $(python_build_path) "$version" "$install_path"
   fi
+
+  if [ "$install_path" != "$symlink_path" ]; then
+    # add a symlink for an alias like:
+    # ~/.asdf/installs/python/3 -> ~/.asdf/installs/python/3.1.2
+    rmdir "$symlink_path" # asdf creates this empty directory we don't want
+    ln -sfv "$install_path" "$symlink_path"
+  fi
 }
 
 install_default_python_packages() {
@@ -36,6 +47,21 @@ install_default_python_packages() {
   if [ -f "$packages_file" ]; then
     echo -ne "\nInstalling default python packages..."
     PATH="$ASDF_INSTALL_PATH/bin:$PATH" pip install -U -r "$packages_file"
+  fi
+}
+
+
+fetch_all_versions() {
+  $(python_build_path) --definitions | grep -E '^\d+\.\d+\.\d+$' | sort -rV
+}
+
+resolve_partial_version() {
+  local version=$1
+  if [[ "$version" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+    # maps a version like "3.0" or "3" to "3.1.2"
+    fetch_all_versions | grep -e "^$version\." | head -n1
+  else
+    echo "$version"
   fi
 }
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -4,7 +4,29 @@ source "$(dirname "$0")/utils.sh"
 
 list_all() {
   install_or_update_python_build
-  $(python_build_path) --definitions | tr '\n' ' '
+  echo $(
+    $(python_build_path) --definitions
+    echo 2
+    echo 2.1
+    echo 2.2
+    echo 2.3
+    echo 2.4
+    echo 2.5
+    echo 2.6
+    echo 2.7
+    echo 3
+    echo 3.0
+    echo 3.1
+    echo 3.2
+    echo 3.3
+    echo 3.4
+    echo 3.5
+    echo 3.6
+    echo 3.7
+    echo 3.8
+    echo 3.9
+    echo 3.10
+  ) | tr '\n' ' '
 }
 
 list_all


### PR DESCRIPTION
this PR allows you to install python via `asdf install python 3.10` or
`asdf install python 3`. It will then install the latest version
starting with that prefix.

It will add an alias in `~/.asdf/installs/python` so you can have a
`.tool-versions` file like the following:

```
python 3.10
```

## Validation

```sh-session
$ asdf install python 3.9
python-build 3.9.13 /Users/jdx/.asdf/installs/python/3.9.13
python-build: use openssl@1.1 from homebrew
python-build: use readline from homebrew
Downloading Python-3.9.13.tar.xz...
-> https://www.python.org/ftp/python/3.9.13/Python-3.9.13.tar.xz
Installing Python-3.9.13...
python-build: use readline from homebrew
python-build: use zlib from xcode sdk
Installed Python-3.9.13 to /Users/jdx/.asdf/installs/python/3.9.13
/Users/jdx/.asdf/installs/python/3.9 -> /Users/jdx/.asdf/installs/python/3.9.13
$ ASDF_PYTHON_VERSION=3.9 python -V
Python 3.9.13
$ ASDF_PYTHON_VERSION=3.9.13 python -V
Python 3.9.13
```