### PR TITLE
fix `asdf latest python`

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -52,7 +52,7 @@ install_default_python_packages() {
 
 
 fetch_all_versions() {
-  $(python_build_path) --definitions | grep -E '^\d+\.\d+\.\d+$' | sort -rV
+  $(python_build_path) --definitions | grep -E '^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$' | sort -rV
 }
 
 resolve_partial_version() {

--- a/bin/install
+++ b/bin/install
@@ -52,7 +52,11 @@ install_default_python_packages() {
 
 
 fetch_all_versions() {
-  $(python_build_path) --definitions | grep -E '^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$' | sort -rV
+  # fetches the definitions, grabs only the ones formatted "x.x.x"
+  # then reverse sorts by version number
+  $(python_build_path) --definitions |
+    grep -E '^([0-9]+\.){2}[0-9]+$' |
+    LC_ALL=C sort -t. -nrk1 -nrk2 -nrk3
 }
 
 resolve_partial_version() {

--- a/bin/install
+++ b/bin/install
@@ -57,9 +57,9 @@ fetch_all_versions() {
 
 resolve_partial_version() {
   local version=$1
-  if [[ "$version" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
-    # maps a version like "3.0" or "3" to "3.1.2"
-    fetch_all_versions | grep -e "^$version\." | head -n1
+  if [[ "$version" =~ -latest$ ]]; then
+    # maps a version like "3.1-latest" to "3.1.2"
+    fetch_all_versions | grep -e "^${version%-latest}\." | head -n1
   else
     echo "$version"
   fi

--- a/bin/list-all
+++ b/bin/list-all
@@ -4,7 +4,29 @@ source "$(dirname "$0")/utils.sh"
 
 list_all() {
   install_or_update_python_build
-  $(python_build_path) --definitions | tr '\n' ' '
+  echo "$(
+    $(python_build_path) --definitions
+    echo 2-latest
+    echo 2.1-latest
+    echo 2.2-latest
+    echo 2.3-latest
+    echo 2.4-latest
+    echo 2.5-latest
+    echo 2.6-latest
+    echo 2.7-latest
+    echo 3-latest
+    echo 3.0-latest
+    echo 3.1-latest
+    echo 3.2-latest
+    echo 3.3-latest
+    echo 3.4-latest
+    echo 3.5-latest
+    echo 3.6-latest
+    echo 3.7-latest
+    echo 3.8-latest
+    echo 3.9-latest
+    echo 3.10-latest
+  )" | tr '\n' ' '
 }
 
 list_all

--- a/bin/list-all
+++ b/bin/list-all
@@ -4,29 +4,7 @@ source "$(dirname "$0")/utils.sh"
 
 list_all() {
   install_or_update_python_build
-  echo $(
-    $(python_build_path) --definitions
-    echo 2
-    echo 2.1
-    echo 2.2
-    echo 2.3
-    echo 2.4
-    echo 2.5
-    echo 2.6
-    echo 2.7
-    echo 3
-    echo 3.0
-    echo 3.1
-    echo 3.2
-    echo 3.3
-    echo 3.4
-    echo 3.5
-    echo 3.6
-    echo 3.7
-    echo 3.8
-    echo 3.9
-    echo 3.10
-  ) | tr '\n' ' '
+  $(python_build_path) --definitions | tr '\n' ' '
 }
 
 list_all


### PR DESCRIPTION
Fixes #140 

This contains bug fixes related to shorthand PR #139.

This makes the partial version lookup compatible with GNU grep and adds a "-latest" suffix to shorthands. `asdf list-all python`  broke `asdf latest python` without that suffix but asdf knows to [ignore versions with `-latest`](https://github.com/asdf-vm/asdf/blob/5334d1db3d390c46ed49101528f74483eb6b2987/lib/functions/versions.bash#L153).

Note this means that `asdf install python 3.7` won't work anymore (but that change was only in for less than 24 hours). We'll need to use `asdf install install python 3.7-latest`.