### PR TITLE
Fix grammar in README.md for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Python 2.7.13
 
 ## Pip installed modules and binaries
 
-If you use pip to install a module like ipython that has binaries. You will need to run `asdf reshim python` for the binary to be in your path.
+If you use pip to install a module like ipython that has binaries, you will need to run `asdf reshim python` for the binary to be in your path.
 
 ## Default Python packages
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix grammar in README.md to improve clarity of the pip/reshim instruction. Adds a comma after "binaries" so the sentence reads correctly.

<sup>Written for commit 8d4a3a94fb26cbf78900cc1b09f8d446bf7cac92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

